### PR TITLE
Change composer autoload type to classmap (IronMQ issue with laravel)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.2.0"
     },
     "autoload": {
-        "files": ["IronCore.class.php"]
+        "classmap": ["IronCore.class.php"]
     },
     "repositories":[
         {


### PR DESCRIPTION
This issue crosses over to https://github.com/iron-io/iron_mq_php but the fix is at least needed here.  There seems to be an order dependancy issue when iron_mq_php is added as a requirement to a fresh laravel install. This results in a  composer autoload_files similar to this: 

```
        return array(
    $vendorDir . '/swiftmailer/swiftmailer/lib/swift_required.php',
    $vendorDir . '/iron-io/iron_mq/IronMQ.class.php',
    $vendorDir . '/ircmaxell/password-compat/lib/password.php',
    $vendorDir . '/laravel/framework/src/Illuminate/Support/helpers.php',
    $vendorDir . '/iron-io/iron_core/IronCore.class.php',
);
```

Since IronMQ loads before IronCore this https://github.com/iron-io/iron_mq_php/blob/master/IronMQ.class.php#L19 triggers and IronMQ doesn't get loaded.  

Long story short, changing the composer autoload type from 'files' to 'classmap' in IronCore (and IronMQ if you want) resolves this issue.
