### PR TITLE
PSR-2 Coding Style

### DIFF
--- a/IronCore.class.php
+++ b/IronCore.class.php
@@ -199,8 +199,12 @@ class IronCore
             throw new InvalidArgumentException("Config file $file not parsed");
         };
 
-        if (!empty($data[$this->product_name])) $this->loadFromHash($data[$this->product_name]);
-        if (!empty($data['iron'])) $this->loadFromHash($data['iron']);
+        if (!empty($data[$this->product_name])) {
+            $this->loadFromHash($data[$this->product_name]);
+        }
+        if (!empty($data['iron'])) {
+            $this->loadFromHash($data['iron']);
+        }
         $this->loadFromHash($data);
     }
 


### PR DESCRIPTION
I've made this repo confirm to these standards where possible. Note that it still does not conform to the namespacing standards, and the exception classes do not conform to the StudlyCaps class naming standard. Also, PSR-2 says we should only have 1 class per file, but I have ignored that.

One other note, the json_decode function does not conform to the camelCase naming convention, but I have not renamed any functions to retain backwards compatibility. Also, this function makes more sense with the name it already had.
