### PR TITLE
Fixing curl upload for PHP 5.6+

### DIFF
--- a/src/IronCore.php
+++ b/src/IronCore.php
@@ -289,6 +289,7 @@ class IronCore
                     curl_setopt($this->curl, CURLOPT_URL, $url);
                     curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, self::POST);
                     curl_setopt($this->curl, CURLOPT_POST, true);
+                    curl_setopt($this->curl, CURLOPT_SAFE_UPLOAD, false);
                     if ($data)
                     {
                         curl_setopt($this->curl, CURLOPT_POSTFIELDS, $data);


### PR DESCRIPTION
Curl safe upload is preventing laraworker to upload code to the server.

Here's where I reported the issue originally:
https://github.com/iron-io/laraworker/issues/5

Setting CURLOPT_SAFE_UPLOAD resolved the issue.
