### PR TITLE
Backport 'remove EOF check before retry on server error' to v0

### DIFF
--- a/IronCore.class.php
+++ b/IronCore.class.php
@@ -335,12 +335,6 @@ class IronCore
                 case self::HTTP_ACCEPTED:
                     return $_out;
                 case Http_Exception::INTERNAL_ERROR:
-                    if (strpos($_out, "EOF") !== false) {
-                        self::waitRandomInterval($retry);
-                    } else {
-                        $this->reportHttpError($this->last_status, $_out);
-                    }
-                    break;
                 case Http_Exception::SERVICE_UNAVAILABLE:
                 case Http_Exception::GATEWAY_TIMEOUT:
                     self::waitRandomInterval($retry);


### PR DESCRIPTION
We haven't yet upgraded to the new version (although we obviously have to soon), but are currently seeing 500 Service Unavailable errors that do not get reattempted. Would you consider backporting the change from the new version?