### PR TITLE
Adding Execute Timeout to Core Iron Request

### DIFF
--- a/src/IronCore.php
+++ b/src/IronCore.php
@@ -56,6 +56,7 @@ class IronCore
     public $debug_enabled      = false;
     public $ssl_verifypeer     = true;
     public $connection_timeout = 60;
+    public $execute_timeout    = 60;
     public $proxy              = null;
     public $proxy_userpwd      = null;
 
@@ -172,7 +173,6 @@ class IronCore
         $this->setVarIfValue('port', $options);
         $this->setVarIfValue('api_version', $options);
         $this->setVarIfValue('encryption_key', $options);
-        $this->setVarIfvalue('connection_timeout', $options);
     }
 
     protected function loadFromEnv($prefix)
@@ -285,6 +285,7 @@ class IronCore
             curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->compiledCurlHeaders());
             curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->connection_timeout);
+            curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->execute_timeout);
         } else {
             $this->debug("Call with URL Fetch", $url);
             if ($type == self::GET) {

--- a/src/IronCore.php
+++ b/src/IronCore.php
@@ -172,6 +172,7 @@ class IronCore
         $this->setVarIfValue('port', $options);
         $this->setVarIfValue('api_version', $options);
         $this->setVarIfValue('encryption_key', $options);
+        $this->setVarIfvalue('connection_timeout', $options);
     }
 
     protected function loadFromEnv($prefix)


### PR DESCRIPTION
To prevent from system issues where Iron functions take longer than X seconds to run and hold up other resources, this allows you to set it in your declarations:

```
$ironMQ = new \IronMQ\IronMQ();
$ironMQ->connection_timeout = 10;
$ironMQ->execute_timeout = 10;
```

This will throw an HTTP Exception when it starts to execute for more than 10s.